### PR TITLE
Explicitly import tables from package

### DIFF
--- a/wpalchemy/classes.py
+++ b/wpalchemy/classes.py
@@ -1,5 +1,5 @@
 import sqlalchemy.orm as orm
-import tables
+from wpalchemy import tables
 
 metadata = tables.metadata
 


### PR DESCRIPTION
Hi! And thanks for working on this this project 😄 

I attempted to install this repo using pip:
```
pip install git+https://github.com/alfredo/wordpress-sqlalchemy.git#egg=wordpress-sqlalchemy
```

However when using it I was presented with the following error:
```
Traceback (most recent call last):
...
  File "/Users/sambriggs/.local/share/virtualenvs/port-skin-deep-HRFIk8Np/lib/python3.6/site-packages/wpalchemy/classes.py", line 2, in <module>
    import tables
ModuleNotFoundError: No module named 'tables'
```

This pull request fixes the import of the **tables** module in **classes** to explicitly reference its package.

Thanks!